### PR TITLE
Fix symbol name extraction from ELF

### DIFF
--- a/src/microsurf/utils/elf.py
+++ b/src/microsurf/utils/elf.py
@@ -41,7 +41,8 @@ def getfnname(file: str, loc: int):
             symtab: SymbolTableSection = elf.get_section_by_name(".symtab")
             for i in range(symtab.num_symbols()):
                 symbol = symtab.get_symbol(i)
-                tmp[symbol["st_value"]] = symbol.name
+                if symbol.name != '' and not symbol.name.startswith('.L'):
+                    tmp[symbol["st_value"]] = symbol.name
         ELFSYBOLS[file] = collections.OrderedDict(
             sorted(tmp.items(), key=lambda t: t[0])
         )


### PR DESCRIPTION
In some cases compilers might add local labels (starting with '.L') in the symbols table. This patch removes these labels as possible targets for a function symbol.

We will have to update the submodule in the eval-infra repo as soon as this is merged.