### PR TITLE
Hardcode unicorn version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ install_requires =
     tornado
     tqdm
     unicodecsv
+    unicorn==2.0.1
     zope.event
     zope.interface
 python_requires = 


### PR DESCRIPTION
Version 2.1.2 seems to be broken. This commit rolls back to a known version.

fixes #53